### PR TITLE
move the service call to the correct entity

### DIFF
--- a/custom_components/alfen_wallbox/alfen.py
+++ b/custom_components/alfen_wallbox/alfen.py
@@ -210,7 +210,8 @@ class AlfenDevice:
                 if prop[ID] == api_param:
                     _LOGGER.debug(f"Set {api_param} value {value}")
                     prop[VALUE] = value
-                    return True
+                    break
+
         return False
 
     async def get_value(self, api_param):
@@ -222,7 +223,7 @@ class AlfenDevice:
         _LOGGER.debug(f"Set current limit {limit}A")
         if limit > 32 | limit < 1:
             return None
-        self.set_value("2129_0", limit)
+        await self.set_value("2129_0", limit)
 
     async def set_rfid_auth_mode(self, enabled):
         _LOGGER.debug(f"Set RFID Auth Mode {enabled}")
@@ -231,13 +232,13 @@ class AlfenDevice:
         if enabled:
             value = 2
 
-        self.set_value("2126_0", value)
+        await self.set_value("2126_0", value)
 
     async def set_current_phase(self, phase):
         _LOGGER.debug(f"Set current phase {phase}")
         if phase not in ('L1', 'L2', 'L3'):
             return None
-        self.set_value("2069_0", phase)
+        await self.set_value("2069_0", phase)
 
     async def set_phase_switching(self, enabled):
         _LOGGER.debug(f"Set Phase Switching {enabled}")
@@ -246,19 +247,19 @@ class AlfenDevice:
         if enabled:
             value = 1
 
-        self.set_value("2185_0", value)
+        await self.set_value("2185_0", value)
 
     async def set_green_share(self, value):
         _LOGGER.debug(f"Set green share value {value}%")
         if value < 0 | value > 100:
             return None
-        self.set_value("3280_2", value)
+        await self.set_value("3280_2", value)
 
     async def set_comfort_power(self, value):
         _LOGGER.debug(f"Set Comfort Level {value}W")
         if value < 1400 | value > 5000:
             return None
-        self.set_value("3280_3", value)
+        await self.set_value("3280_3", value)
 
     def __get_url(self, action) -> str:
         return "https://{}/api/{}".format(self.host, action)

--- a/custom_components/alfen_wallbox/binary_sensor.py
+++ b/custom_components/alfen_wallbox/binary_sensor.py
@@ -55,8 +55,6 @@ async def async_setup_entry(
 class AlfenBinarySensor(AlfenEntity, BinarySensorEntity):
     """Define an Alfen binary sensor."""
 
-    # entity_description: AlfenBinaryDescriptionMixin
-
     def __init__(self,
                  device: AlfenDevice,
                  description: AlfenBinaryDescription

--- a/custom_components/alfen_wallbox/select.py
+++ b/custom_components/alfen_wallbox/select.py
@@ -3,7 +3,9 @@ from typing import Final, Any
 
 from dataclasses import dataclass
 
-from .const import ID, VALUE
+from homeassistant.helpers import entity_platform
+
+from .const import ID, SERVICE_DISABLE_RFID_AUTHORIZATION_MODE, SERVICE_ENABLE_RFID_AUTHORIZATION_MODE, SERVICE_SET_CURRENT_PHASE, VALUE
 from .entity import AlfenEntity
 
 from homeassistant.config_entries import ConfigEntry
@@ -18,6 +20,9 @@ from homeassistant.components.select import (
 
 from homeassistant.core import HomeAssistant, callback
 from . import DOMAIN as ALFEN_DOMAIN
+
+import voluptuous as vol
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -228,6 +233,27 @@ async def async_setup_entry(
 
     async_add_entities(selects)
 
+    platform = entity_platform.current_platform.get()
+
+    platform.async_register_entity_service(
+        SERVICE_SET_CURRENT_PHASE,
+        {
+            vol.Required("phase"): str,
+        },
+        "async_set_current_phase",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_ENABLE_RFID_AUTHORIZATION_MODE,
+        {},
+        "async_enable_rfid_auth_mode",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_DISABLE_RFID_AUTHORIZATION_MODE,
+        {},
+        "async_disable_rfid_auth_mode",
+    )
 
 class AlfenSelect(AlfenEntity, SelectEntity):
     """Define Alfen select."""
@@ -275,3 +301,20 @@ class AlfenSelect(AlfenEntity, SelectEntity):
     def _async_update_attrs(self) -> None:
         """Update select attributes."""
         self._attr_current_option = self._get_current_option()
+
+    async def async_set_current_phase(self, phase):
+        """Set the current phase."""
+        await self._device.set_current_phase(phase)
+        await self.async_select_option(phase)
+
+    async def async_enable_rfid_auth_mode(self):
+        """Enable RFID authorization mode."""
+        await self._device.set_rfid_auth_mode(True)
+        await self.update_state(self.entity_description.api_param, 2)
+        self.async_write_ha_state()
+
+    async def async_disable_rfid_auth_mode(self):
+        """Disable RFID authorization mode."""
+        await self._device.set_rfid_auth_mode(False)
+        await self.update_state(self.entity_description.api_param, 0)
+        self.async_write_ha_state()

--- a/custom_components/alfen_wallbox/sensor.py
+++ b/custom_components/alfen_wallbox/sensor.py
@@ -33,14 +33,6 @@ from .alfen import AlfenDevice
 from .const import (
     ID,
     SERVICE_REBOOT_WALLBOX,
-    SERVICE_SET_CURRENT_LIMIT,
-    SERVICE_ENABLE_RFID_AUTHORIZATION_MODE,
-    SERVICE_DISABLE_RFID_AUTHORIZATION_MODE,
-    SERVICE_SET_CURRENT_PHASE,
-    SERVICE_ENABLE_PHASE_SWITCHING,
-    SERVICE_DISABLE_PHASE_SWITCHING,
-    SERVICE_SET_GREEN_SHARE,
-    SERVICE_SET_COMFORT_POWER,
     VALUE,
 )
 
@@ -610,62 +602,6 @@ async def async_setup_entry(
         "async_reboot_wallbox",
     )
 
-    platform.async_register_entity_service(
-        SERVICE_SET_CURRENT_LIMIT,
-        {
-            vol.Required("limit"): cv.positive_int,
-        },
-        "async_set_current_limit",
-    )
-
-    platform.async_register_entity_service(
-        SERVICE_SET_CURRENT_PHASE,
-        {
-            vol.Required("phase"): str,
-        },
-        "async_set_current_phase",
-    )
-
-    platform.async_register_entity_service(
-        SERVICE_ENABLE_RFID_AUTHORIZATION_MODE,
-        {},
-        "async_enable_rfid_auth_mode",
-    )
-
-    platform.async_register_entity_service(
-        SERVICE_DISABLE_RFID_AUTHORIZATION_MODE,
-        {},
-        "async_disable_rfid_auth_mode",
-    )
-
-    platform.async_register_entity_service(
-        SERVICE_ENABLE_PHASE_SWITCHING,
-        {},
-        "async_enable_phase_switching",
-    )
-
-    platform.async_register_entity_service(
-        SERVICE_DISABLE_PHASE_SWITCHING,
-        {},
-        "async_disable_phase_switching",
-    )
-
-    platform.async_register_entity_service(
-        SERVICE_SET_GREEN_SHARE,
-        {
-            vol.Required(VALUE): cv.positive_int,
-        },
-        "async_set_green_share",
-    )
-
-    platform.async_register_entity_service(
-        SERVICE_SET_COMFORT_POWER,
-        {
-            vol.Required(VALUE): cv.positive_int,
-        },
-        "async_set_comfort_power",
-    )
-
 
 class AlfenMainSensor(AlfenEntity):
     def __init__(self, device: AlfenDevice, description: AlfenSensorDescription) -> None:
@@ -707,41 +643,11 @@ class AlfenMainSensor(AlfenEntity):
         """Reboot the wallbox."""
         await self._device.reboot_wallbox()
 
-    async def async_set_current_limit(self, limit):
-        """Set the current limit."""
-        await self._device.set_current_limit(limit)
-
-    async def async_enable_rfid_auth_mode(self):
-        """Enable RFID authorization mode."""
-        await self._device.set_rfid_auth_mode(True)
-
-    async def async_disable_rfid_auth_mode(self):
-        """Disable RFID authorization mode."""
-        await self._device.set_rfid_auth_mode(False)
-
     async def async_update(self):
         """Update the sensor."""
         await self._device.async_update()
 
-    async def async_set_current_phase(self, phase):
-        """Set the current phase."""
-        await self._device.set_current_phase(phase)
 
-    async def async_enable_phase_switching(self):
-        """Enable phase switching."""
-        await self._device.set_phase_switching(True)
-
-    async def async_disable_phase_switching(self):
-        """Disable phase switching."""
-        await self._device.set_phase_switching(False)
-
-    async def async_set_green_share(self, value):
-        """Set the green share."""
-        await self._device.set_green_share(value)
-
-    async def async_set_comfort_power(self, value):
-        """Set the comfort power."""
-        await self._device.set_comfort_power(value)
 
     @property
     def device_info(self):

--- a/custom_components/alfen_wallbox/services.yaml
+++ b/custom_components/alfen_wallbox/services.yaml
@@ -10,61 +10,65 @@ set_current_limit:
   fields:
     entity_id:
       description: Name(s) of entities to change.
-      example: "alfen_wallbox.garage"
+      example: "number.wallbox_current_limit"
     limit:
       description: New limit.
+      example: 16
 
 enable_rfid_authorization_mode:
   description: Enables RFID auth mode
   fields:
     entity_id:
       description: Name(s) of entities to change.
-      example: "alfen_wallbox.garage"
+      example: "select.wallbox_authorization_mode"
 
 disable_rfid_authorization_mode:
   description: Disables RFID auth mode
   fields:
     entity_id:
       description: Name(s) of entities to change.
-      example: "alfen_wallbox.garage"
+      example: "select.wallbox_authorization_mode"
 
 set_current_phase:
-  description: Set current phase mapping to L1
+  description: Set current phase mapping
   fields:
     entity_id:
       description: Name(s) of entities to change.
-      example: "alfen_wallbox.garage"
+      example: "select.wallbox_active_load_balancing_phase_connection"
     phase:
       description: phase.
+      example: "L1"
 
 enable_phase_switching:
   description: Enable phase switching
   fields:
     entity_id:
       description: Name(s) of entities to change.
-      example: "alfen_wallbox.garage"
+      example: "switch.wallbox_enable_phase_switching"
 
 disable_phase_switching:
   description: Disable phase switching
   fields:
     entity_id:
       description: Name(s) of entities to change.
-      example: "alfen_wallbox.garage"
+      example: "switch.wallbox_enable_phase_switching"
 
 set_green_share:
   description: Set Green Share Percentage
   fields:
     entity_id:
       description: Name(s) of entities to change.
-      example: "alfen_wallbox.garage"
+      example: "number.wallbox_solar_green_share"
     value:
       description: New value.
+      example: 80
 
 set_comfort_power:
   description: Set Solar Comfort Power
   fields:
     entity_id:
       description: Name(s) of entities to change.
-      example: "alfen_wallbox.garage"
+      example: "number.wallbox_solar_comfort_level"
     value:
       description: New value.
+      example: 1400

--- a/custom_components/alfen_wallbox/switch.py
+++ b/custom_components/alfen_wallbox/switch.py
@@ -3,7 +3,9 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Final
 
-from .const import ID, VALUE
+from homeassistant.helpers import entity_platform
+
+from .const import ID, SERVICE_DISABLE_PHASE_SWITCHING, SERVICE_ENABLE_PHASE_SWITCHING, VALUE
 from .alfen import AlfenDevice
 from .entity import AlfenEntity
 
@@ -55,6 +57,20 @@ async def async_setup_entry(
 
     async_add_entities(switches)
 
+    platform = entity_platform.current_platform.get()
+
+    platform.async_register_entity_service(
+        SERVICE_ENABLE_PHASE_SWITCHING,
+        {},
+        "async_enable_phase_switching",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_DISABLE_PHASE_SWITCHING,
+        {},
+        "async_disable_phase_switching",
+    )
+
 
 class AlfenSwitchSensor(AlfenEntity, SwitchEntity):
     """Define an Alfen binary sensor."""
@@ -95,3 +111,13 @@ class AlfenSwitchSensor(AlfenEntity, SwitchEntity):
         """Turn the entity off."""
         await self.update_state(self.entity_description.api_param, 0)
         await self._device.async_update()
+
+    async def async_enable_phase_switching(self):
+        """Enable phase switching."""
+        await self._device.set_phase_switching(True)
+        await self.async_turn_on()
+
+    async def async_disable_phase_switching(self):
+        """Disable phase switching."""
+        await self._device.set_phase_switching(False)
+        await self.async_turn_off()


### PR DESCRIPTION
After splitting up the entity from the sensor to switch, binary, number,...
didn't see that we also need to move the services call