### PR TITLE
set max current on 32A to 40A #84

### DIFF
--- a/custom_components/alfen_wallbox/number.py
+++ b/custom_components/alfen_wallbox/number.py
@@ -514,8 +514,8 @@ class AlfenNumber(AlfenEntity, NumberEntity):
         # check if device licenses has the high power socket license
         if LICENSE_HIGH_POWER in self._device.licenses:
             if description.api_param in override_amps_api_key:
-                self._attr_max_value = 32
-                self._attr_native_max_value = 32
+                self._attr_max_value = 40
+                self._attr_native_max_value = 40
 
     @property
     def native_value(self) -> float | None:


### PR DESCRIPTION
[set max current on 32A to 40A](https://github.com/leeyuentuen/alfen_wallbox/commit/686d1f6036d8d79ccf0764982ef65ae4e4aa823f) 