### PR TITLE
Fix/units

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ data:
 
 > After reverse engineering the API myself I found out that there is already a Python libary wrapping the Alfen API.
 > https://gitlab.com/LordGaav/alfen-eve/-/tree/develop/alfeneve
+> https://github.com/leeyuentuen/alfen_wallbox/wiki/API-paramID
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ data:
 
 > After reverse engineering the API myself I found out that there is already a Python libary wrapping the Alfen API.
 > https://gitlab.com/LordGaav/alfen-eve/-/tree/develop/alfeneve
+> 
 > https://github.com/leeyuentuen/alfen_wallbox/wiki/API-paramID
 
 ## Installation

--- a/custom_components/alfen_wallbox/number.py
+++ b/custom_components/alfen_wallbox/number.py
@@ -173,7 +173,7 @@ ALFEN_NUMBER_TYPES: Final[tuple[AlfenNumberDescription, ...]] = (
         native_max_value=30,
         native_step=1,
         custom_mode=None,
-        unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        unit_of_measurement=UnitOfTime.SECONDS,
         api_param="21B9_0",
         round_digits=None,
     ),
@@ -368,7 +368,7 @@ ALFEN_NUMBER_TYPES: Final[tuple[AlfenNumberDescription, ...]] = (
         native_max_value=30,
         native_step=1,
         custom_mode=None,
-        unit_of_measurement=CURRENCY_EURO,
+        unit_of_measurement=UnitOfTime.SECONDS,
         api_param="2136_0",
         round_digits=None
     ),
@@ -384,7 +384,7 @@ ALFEN_NUMBER_TYPES: Final[tuple[AlfenNumberDescription, ...]] = (
         native_max_value=30,
         native_step=1,
         custom_mode=None,
-        unit_of_measurement=CURRENCY_EURO,
+        unit_of_measurement=UnitOfTime.SECONDS,
         api_param="2184_0",
         round_digits=None
     ),
@@ -400,7 +400,7 @@ ALFEN_NUMBER_TYPES: Final[tuple[AlfenNumberDescription, ...]] = (
         native_max_value=30,
         native_step=1,
         custom_mode=None,
-        unit_of_measurement=CURRENCY_EURO,
+        unit_of_measurement=UnitOfTime.SECONDS,
         api_param="2168_0",
         round_digits=None
     ),


### PR DESCRIPTION
Hi!

I noticed that some entities have a wrong unit of measurement:
* number.alfen_eve_car_disconnection_timeout_s: € should be s
* number.alfen_eve_car_time_to_report_not_charging_s: € should be s
* number.alfen_eve_car_time_to_unlock_not_charging_s: € should be s
* number.alfen_eve_load_balancing_charging_profiles_random_delay: A should be s