### PR TITLE
adjust SCAN_INTERVAL and TIMEOUT to avoid accumulating threads

### DIFF
--- a/custom_components/alfen_wallbox/const.py
+++ b/custom_components/alfen_wallbox/const.py
@@ -41,7 +41,7 @@ CAT_METER2 = "meter2"
 COMMAND_REBOOT = "reboot"
 
 
-TIMEOUT = 90
+TIMEOUT = 20
 
 SERVICE_REBOOT_WALLBOX = "reboot_wallbox"
 SERVICE_SET_CURRENT_LIMIT = "set_current_limit"

--- a/custom_components/alfen_wallbox/sensor.py
+++ b/custom_components/alfen_wallbox/sensor.py
@@ -35,7 +35,7 @@ from .const import ID, SERVICE_REBOOT_WALLBOX, VALUE
 from .entity import AlfenEntity
 
 _LOGGER = logging.getLogger(__name__)
-SCAN_INTERVAL = timedelta(seconds=5)
+SCAN_INTERVAL = timedelta(seconds=30)
 
 
 @dataclass


### PR DESCRIPTION
The problem I'm facing is that HA starts accumulating threads when Alfen becomes unavailable. It happens because SCAN_INTERVAL=5s, while the request timeout is 90s. Timeout should be smaller than the interval to avoid accumulating threads.

There are two ways out:

1. Set TIMEOUT < 5s.
2. Increase SCAN_INTERVAL.

I suggest taking (2) because the 5s interval is too frequent.

P.S. Sorry for the noise. I forgot to create a branch. Hence, recreated PR (https://github.com/leeyuentuen/alfen_wallbox/pull/103).