### PR TITLE
prevent infinite loop in _get_all_properties_value()

### DIFF
--- a/custom_components/alfen_wallbox/alfen.py
+++ b/custom_components/alfen_wallbox/alfen.py
@@ -263,16 +263,26 @@ class AlfenDevice:
         for cat in (CAT_GENERIC, CAT_GENERIC2, CAT_METER1, CAT_STATES, CAT_TEMP, CAT_OCPP, CAT_METER4, CAT_MBUS_TCP, CAT_COMM, CAT_DISPLAY, CAT_METER2):
             nextRequest = True
             offset = 0
+            attempt = 0
             while (nextRequest):
+                attempt += 1
                 cmd = f"{PROP}?{CAT}={cat}&{OFFSET}={offset}"
                 response = await self._get(url=self.__get_url(cmd))
                 _LOGGER.debug(f"Status Response {cmd}: {response}")
 
                 if response is not None:
+                    attempt = 0
                     properties += response[PROPERTIES]
                     nextRequest = response[TOTAL] > (
                         offset + len(response[PROPERTIES]))
                     offset += len(response[PROPERTIES])
+                elif attempt >= 3:
+                    # This only possible in case of series of timeouts or unknown exceptions in self._get()
+                    # It's better to break completely, otherwise we can provide partial data in self.properties.
+                    _LOGGER.debug(f"Returning earlier after {attempt} attempts")
+                    self.properties = []
+                    return
+
         _LOGGER.debug(f"Properties {properties}")
         self.properties = properties
 

--- a/custom_components/alfen_wallbox/alfen.py
+++ b/custom_components/alfen_wallbox/alfen.py
@@ -243,10 +243,9 @@ class AlfenDevice:
 
     async def _get_value(self, api_param):
         """Get a value from the API."""
-        response = await self._get(url=self.__get_url(
-            f"{PROP}?{ID}={api_param}"))
-
-        _LOGGER.debug(f"Status Response {response}")
+        cmd = f"{PROP}?{ID}={api_param}"
+        response = await self._get(url=self.__get_url(cmd))
+        _LOGGER.debug(f"Status Response {cmd}: {response}")
 
         if response is not None:
             if self.properties is None:
@@ -265,9 +264,10 @@ class AlfenDevice:
             nextRequest = True
             offset = 0
             while (nextRequest):
-                response = await self._get(url=self.__get_url(
-                    f"{PROP}?{CAT}={cat}&{OFFSET}={offset}"))
-                _LOGGER.debug(f"Status Response {response}")
+                cmd = f"{PROP}?{CAT}={cat}&{OFFSET}={offset}"
+                response = await self._get(url=self.__get_url(cmd))
+                _LOGGER.debug(f"Status Response {cmd}: {response}")
+
                 if response is not None:
                     properties += response[PROPERTIES]
                     nextRequest = response[TOTAL] > (


### PR DESCRIPTION
When Alfen wallbox becomes unavailable (can't ping/connect) `_get_all_properties_value()` in `alfen.py` goes into an infinite loop which prevents it from putting sensors into an "Unknown" state.

Such behavior happens because if `response` is None due to a timeout or any other exception, `nextRequest` remains True and `while()` loop continues indefinitely. Hence, `_get_all_properties_value()` never finishes, and `self.properties` is never set to an empty state. As a result, all sensors continue to use the last known state.

This PR fixes it. It allows 3 failures before giving up though.

P.S. I've also improved logging a bit to simplify debugging.