### PR TITLE
Other tariff

### DIFF
--- a/custom_components/alfen_wallbox/number.py
+++ b/custom_components/alfen_wallbox/number.py
@@ -371,6 +371,21 @@ ALFEN_NUMBER_TYPES: Final[tuple[AlfenNumberDescription, ...]] = (
         round_digits=2
     ),
     AlfenNumberDescription(
+        key="price_price_other",
+        name="Price other",
+        state=None,
+        icon="mdi:currency-eur",
+        assumed_state=False,
+        device_class=None,
+        native_min_value=-5,
+        native_max_value=5,
+        native_step=0.01,
+        custom_mode=NumberMode.BOX,
+        unit_of_measurement=CURRENCY_EURO,
+        api_param="3262_6",
+        round_digits=2
+    ),
+    AlfenNumberDescription(
         key="ev_disconnection_timeout",
         name="Car Disconnection Timeout (s)",
         state=None,

--- a/custom_components/alfen_wallbox/text.py
+++ b/custom_components/alfen_wallbox/text.py
@@ -59,6 +59,13 @@ ALFEN_TEXT_TYPES: Final[tuple[AlfenTextDescription, ...]] = (
         mode=TextMode.PASSWORD,
         api_param="2116_1"
     ),
+    AlfenTextDescription(
+        key="price_other_description",
+        name="Price other description",
+        icon="mdi:tag-text-outline",
+        mode=TextMode.TEXT,
+        api_param="3262_7"
+    ),
 )
 
 


### PR DESCRIPTION
In a recent firmware update Alfen has added the Other tariff (with descriptor text) to the charge point configuration. This pull requests adds both fields into the integration.

(Both fields can be initially hidden but I was not able to find out how to implement that)