### PR TITLE
Reduce error logging when logged out

### DIFF
--- a/custom_components/alfen_wallbox/alfen.py
+++ b/custom_components/alfen_wallbox/alfen.py
@@ -201,7 +201,8 @@ class AlfenDevice:
         except TimeoutError:
             _LOGGER.warning("Timeout on POST")
         except Exception as e:  # pylint: disable=broad-except  # noqa: BLE001
-            _LOGGER.error("Unexpected error on POST %s", str(e))
+            if not allowed_login:
+                _LOGGER.error("Unexpected error on POST %s", str(e))
 
         return None
 
@@ -232,7 +233,8 @@ class AlfenDevice:
             _LOGGER.warning("Timeout on GET")
             return None
         except Exception as e:  # pylint: disable=broad-except  # noqa: BLE001
-            _LOGGER.error("Unexpected error on GET %s", str(e))
+            if not allowed_login:
+                _LOGGER.error("Unexpected error on GET %s", str(e))
             return None
 
     async def login(self):
@@ -293,7 +295,8 @@ class AlfenDevice:
                 response.raise_for_status()
                 return response
         except Exception as e:  # pylint: disable=broad-except  # noqa: BLE001
-            _LOGGER.error("Unexpected error on UPDATE VALUE %s", str(e))
+            if not allowed_login:
+                _LOGGER.error("Unexpected error on UPDATE VALUE %s", str(e))
             return None
 
     async def _get_value(self, api_param):

--- a/custom_components/alfen_wallbox/manifest.json
+++ b/custom_components/alfen_wallbox/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "alfen_wallbox",
     "name": "Alfen Wallbox",
-    "version": "2.9.4-beta-1",
+    "version": "2.9.2-beta-6",
     "config_flow": true,
     "documentation": "https://github.com/leeyuentuen/alfen_wallbox",
     "dependencies": [],


### PR DESCRIPTION
- Fix https://github.com/leeyuentuen/alfen_wallbox/issues/172

This error exists in my logs too. But only once, so I expect the sessions was logged out. There already is a fallback to re-login, so I expect this fixes it already. Reducing errors here would be sufficient.