### PR TITLE
Add switch and select to control Active Load Balancing

### DIFF
--- a/custom_components/alfen_wallbox/select.py
+++ b/custom_components/alfen_wallbox/select.py
@@ -52,8 +52,8 @@ PHASE_ROTATION_DICT: Final[dict[str, str]] = {
 AUTH_MODE_DICT: Final[dict[str, int]] = {"Plug and Charge": 0, "RFID": 2}
 
 LOAD_BALANCE_MODE_DICT: Final[dict[str, int]] = {
-    "Modbus TCP/IP": 0,
-    "DSMR4.x / SMR5.0 (P1)": 3,
+    "Disabled": 0,
+    "Enabled": 3,
 }
 
 LOAD_BALANCE_DATA_SOURCE_DICT: Final[dict[str, int]] = {

--- a/custom_components/alfen_wallbox/select.py
+++ b/custom_components/alfen_wallbox/select.py
@@ -51,9 +51,10 @@ PHASE_ROTATION_DICT: Final[dict[str, str]] = {
 
 AUTH_MODE_DICT: Final[dict[str, int]] = {"Plug and Charge": 0, "RFID": 2}
 
-LOAD_BALANCE_MODE_DICT: Final[dict[str, int]] = {
-    "Disabled": 0,
-    "Enabled": 3,
+LOAD_BALANCE_PROTOCOL_DICT: Final[dict[str, int]] = {
+    "Energy Management System": -1,
+    "Modbus TCP/IP": 4,
+    "DSMR4.x/SMR5.0 (P1)": 5,
 }
 
 LOAD_BALANCE_DATA_SOURCE_DICT: Final[dict[str, int]] = {
@@ -161,12 +162,12 @@ ALFEN_SELECT_TYPES: Final[tuple[AlfenSelectDescription, ...]] = (
         api_param="2126_0",
     ),
     AlfenSelectDescription(
-        key="load_balancing_mode",
-        name="Load Balancing Mode",
+        key="load_balancing_protocol",
+        name="Load Balancing Protocol",
         icon="mdi:scale-balance",
-        options=list(LOAD_BALANCE_MODE_DICT),
-        options_dict=LOAD_BALANCE_MODE_DICT,
-        api_param="2064_0",
+        options=list(LOAD_BALANCE_PROTOCOL_DICT),
+        options_dict=LOAD_BALANCE_PROTOCOL_DICT,
+        api_param="5217_0",
     ),
     AlfenSelectDescription(
         key="lb_active_balancing_received_measurements",

--- a/custom_components/alfen_wallbox/switch.py
+++ b/custom_components/alfen_wallbox/switch.py
@@ -72,6 +72,11 @@ ALFEN_BINARY_SENSOR_TYPES: Final[tuple[AlfenSwitchDescription, ...]] = (
         name="Proxy Enabled",
         api_param="2117_0",
     ),
+    AlfenSwitchDescription(
+        key="active_load_balancing",
+        name="Active Load Balancing",
+        api_param="2064_0",
+    ),
 )
 
 
@@ -132,7 +137,7 @@ class AlfenSwitchSensor(AlfenEntity, SwitchEntity):
         """Return True if entity is on."""
         for prop in self.coordinator.device.properties:
             if prop[ID] == self.entity_description.api_param:
-                return prop[VALUE] == 1
+                return prop[VALUE] == 1 or 3
 
         return False
 
@@ -147,7 +152,14 @@ class AlfenSwitchSensor(AlfenEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         # Do the turning on.
-        await self.coordinator.device.set_value(self.entity_description.api_param, 1)
+        if self.entity_description.api_param == "2064_0":
+            on_value = 3
+        else:
+            on_value = 1
+
+        await self.coordinator.device.set_value(
+            self.entity_description.api_param, on_value
+        )
         await self.coordinator.device.async_update()
 
     async def async_turn_off(self, **kwargs: Any) -> None:


### PR DESCRIPTION
- Add switch to enable/disable Active Load Balancing. Fix #102 
- Add select to select LB protocol

I expect the select `Alfen Load Balancing Data Source` is obsolete. The property is not in the MyEve app (at my settings). 