### PR TITLE
Fix: Switch state is always true

### DIFF
--- a/custom_components/alfen_wallbox/switch.py
+++ b/custom_components/alfen_wallbox/switch.py
@@ -137,7 +137,7 @@ class AlfenSwitchSensor(AlfenEntity, SwitchEntity):
         """Return True if entity is on."""
         for prop in self.coordinator.device.properties:
             if prop[ID] == self.entity_description.api_param:
-                return prop[VALUE] == 1 or 3
+                return prop[VALUE] in [1, 3]
 
         return False
 


### PR DESCRIPTION
Fixed an issue in the switch.py in method is_on, where an incorrect boolean check is performed, which results in always true.

The problem is mentioned in issue #194 